### PR TITLE
Add GitHub Actions CI + Dependabot, future-proof deploy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main, master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type-check
+        run: npm run check
+
+      - name: Build
+        run: npm run build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,11 @@ permissions:
   pages: write
   id-token: write
 
+# Run GitHub's Pages actions (upload-pages-artifact, deploy-pages) on Node 24
+# so they don't hit the Node 20 deprecation.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 # Allow one concurrent deployment, cancel in-progress runs.
 concurrency:
   group: pages
@@ -20,10 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm


### PR DESCRIPTION
Sets up a proper GitHub Actions CI pipeline and clears the Node 20 deprecation on the deploy workflow.

## Changes
- **CI workflow** (`.github/workflows/ci.yml`): runs `astro check` (type-check) + `astro build` on every pull request and push to `master`. Replaces the dead CircleCI integration.
- **Deploy future-proofing**: `actions/checkout@v5` + `actions/setup-node@v5`, and `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` so GitHub's Pages actions also run on Node 24 (no more Node 20 deprecation warnings).
- **Dependabot version updates** (`.github/dependabot.yml`): weekly PRs for `npm` deps and the GitHub Actions themselves, so future action/dep deprecations get auto-bumped.

## Note (manual)
- CircleCI is still connected to the repo as an external check (leftover integration) and reports "No configuration was found". Disconnect it in the CircleCI dashboard (Project Settings → stop building / unfollow) or remove its GitHub App access; it can't be removed from code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)