### PR TITLE
Enable Cloudflare Web Analytics

### DIFF
--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -14,5 +14,5 @@ export const site = {
   },
   // Cloudflare Web Analytics beacon token. Leave empty to disable the beacon
   // (the site is also eligible for Cloudflare's automatic, codeless setup).
-  cloudflareAnalyticsToken: '',
+  cloudflareAnalyticsToken: '6240093bed2f4e2a998e04f9a633a9e4',
 } as const;


### PR DESCRIPTION
Adds the Cloudflare Web Analytics beacon token to `src/data/site.ts`, so the free privacy-first beacon loads on every page (NL + EN).

🤖 Generated with [Claude Code](https://claude.com/claude-code)