### PR TITLE
Prepare for Cloudflare Pages hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,18 @@ Most copy lives in `src/data/`:
 
 ## Deployment
 
-Pushing to `main` triggers the GitHub Actions workflow, which builds the site
-and publishes `dist/` to GitHub Pages. In the repo: Settings → Pages → Source =
-"GitHub Actions" must be enabled once.
+Hosted on **Cloudflare Pages** (build from Git): build command `npm run build`,
+output directory `dist`. Config lives in `wrangler.toml`; security and cache
+headers in `public/_headers`. The Node version comes from `.nvmrc`.
+
+One-time setup in the Cloudflare dashboard:
+
+1. Workers & Pages → Create → Pages → Connect to Git → this repo.
+2. Production branch `master`, framework preset **Astro** (build `npm run build`,
+   output `dist`).
+3. After the first deploy: Custom domains → add `russchenmedia.nl` (Cloudflare
+   updates DNS automatically).
+
+A GitHub Actions workflow (`.github/workflows/deploy.yml`) can still publish to
+GitHub Pages as a fallback; remove it once the Cloudflare Pages cutover is
+confirmed.

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,13 @@
+# Cloudflare Pages headers (https://developers.cloudflare.com/pages/configuration/headers/)
+
+/*
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: DENY
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: geolocation=(), camera=(), microphone=()
+  Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+  Content-Security-Policy: default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com; connect-src 'self' https://api.web3forms.com https://cloudflareinsights.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self' https://api.web3forms.com
+
+# Fingerprinted assets can be cached forever.
+/_astro/*
+  Cache-Control: public, max-age=31536000, immutable

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,3 @@
+name = "russchenmedia"
+compatibility_date = "2025-06-01"
+pages_build_output_dir = "dist"


### PR DESCRIPTION
Prep to host russchenmedia.nl on **Cloudflare Pages** (consolidating with the DNS/proxy/analytics already on Cloudflare).

## Repo changes
- `wrangler.toml` with `pages_build_output_dir = "dist"`.
- `public/_headers`: security headers (CSP, HSTS, X-Frame-Options, Referrer-Policy, Permissions-Policy) + immutable caching for `/_astro/*`. These apply on Cloudflare Pages; GitHub Pages ignores the file.
- README: Cloudflare Pages setup steps.

No behavioural change on the current GitHub Pages deploy. The Actions workflow stays as a fallback until cutover is confirmed.

## Manual cutover (Cloudflare dashboard)
1. Workers & Pages → Create → Pages → Connect to Git → this repo.
2. Production branch `master`, preset **Astro** (build `npm run build`, output `dist`).
3. After first deploy: Custom domains → add `russchenmedia.nl` (DNS auto-updates).
4. Verify on the `*.pages.dev` preview (incl. CSP/headers), then turn off GitHub Pages and remove `deploy.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)