### PR TITLE
Fix Cloudflare deploy (Workers Static Assets config)

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,3 +1,8 @@
 name = "russchenmedia"
 compatibility_date = "2025-06-01"
-pages_build_output_dir = "dist"
+
+# Static site via Cloudflare Workers Static Assets. `wrangler deploy` uploads
+# the build output; there is no Worker script (assets-only). Security and cache
+# headers live in public/_headers (shipped into dist/).
+[assets]
+directory = "./dist"


### PR DESCRIPTION
The Cloudflare build runs `npx wrangler deploy`, which needs a Worker/assets config rather than `pages_build_output_dir`. Switches `wrangler.toml` to assets-only Workers Static Assets (`[assets] directory = "./dist"`). Validated locally with `wrangler deploy --dry-run` (36 assets, no errors). `_headers` still applies under Workers Static Assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)