### PR TITLE
EN on .com root, live dark mode, contact form

### DIFF
--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -79,6 +79,13 @@ const sections = [
   document.querySelectorAll('.nav__panel a').forEach((a) =>
     a.addEventListener('click', () => a.closest('details')?.removeAttribute('open'))
   );
+
+  // Follow the device theme live, unless the visitor picked a theme manually.
+  matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
+    if (localStorage.getItem('theme')) return;
+    root.dataset.theme = e.matches ? 'dark' : 'light';
+    if (meta) meta.setAttribute('content', e.matches ? '#0d1117' : '#ffffff');
+  });
 </script>
 
 <style>

--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -17,5 +17,5 @@ export const site = {
   cloudflareAnalyticsToken: '6240093bed2f4e2a998e04f9a633a9e4',
   // Web3Forms access key for the contact form. Leave empty to fall back to a
   // plain mailto button. Get a free key at https://web3forms.com.
-  web3formsKey: '',
+  web3formsKey: 'a3c26d12-234b-4384-9640-122992b0b4e1',
 } as const;

--- a/worker/index.js
+++ b/worker/index.js
@@ -1,0 +1,21 @@
+/**
+ * Static site served from the ASSETS binding, with host-based routing:
+ * russchenmedia.com (and www) serve the English site at the root, while
+ * russchenmedia.nl serves Dutch at the root and English under /en/.
+ */
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+    const host = url.hostname;
+    const isCom = host === 'russchenmedia.com' || host === 'www.russchenmedia.com';
+
+    // On the .com domain, serve the English homepage at the root.
+    if (isCom && (url.pathname === '/' || url.pathname === '')) {
+      const target = new URL(request.url);
+      target.pathname = '/en/';
+      return env.ASSETS.fetch(new Request(target, request));
+    }
+
+    return env.ASSETS.fetch(request);
+  },
+};

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,8 +1,26 @@
 name = "russchenmedia"
 compatibility_date = "2025-06-01"
+main = "worker/index.js"
 
-# Static site via Cloudflare Workers Static Assets. `wrangler deploy` uploads
-# the build output; there is no Worker script (assets-only). Security and cache
-# headers live in public/_headers (shipped into dist/).
+# Static site via Cloudflare Workers Static Assets. The Worker runs first so it
+# can route by hostname (russchenmedia.com serves English at the root), then
+# serves files through the ASSETS binding. Headers live in public/_headers.
 [assets]
 directory = "./dist"
+binding = "ASSETS"
+run_worker_first = true
+
+[observability]
+enabled = false
+head_sampling_rate = 1
+
+[observability.logs]
+enabled = true
+head_sampling_rate = 1
+persist = true
+invocation_logs = true
+
+[observability.traces]
+enabled = false
+persist = true
+head_sampling_rate = 1


### PR DESCRIPTION
- **.com → English root**: a Worker () with the ASSETS binding and `run_worker_first` routes by hostname. `russchenmedia.com`/`www` serve the English homepage at `/`; `.nl` stays NL at `/`, EN at `/en/`.
- **wrangler.toml**: Worker + assets binding; observability (logs) added.
- **Dark mode**: now follows the device live (`prefers-color-scheme` change) unless the visitor used the toggle.
- **Contact form**: activated via the Web3Forms key in `site.ts`.

Validated with `astro build`, `astro check` (0 issues) and `wrangler deploy --dry-run`.

After merge: add `russchenmedia.com` to Cloudflare and attach it (+ www) as a custom domain on the Worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)