### PR TITLE
Make russchenmedia.com a first-class English site

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -16,9 +16,13 @@ export default defineConfig({
   },
   integrations: [
     sitemap({
-      i18n: {
-        defaultLocale: 'nl',
-        locales: { nl: 'nl', en: 'en' },
+      // English is canonical on russchenmedia.com, so map the built /en/ URL
+      // to its .com address in the sitemap.
+      serialize(item) {
+        if (item.url === 'https://russchenmedia.nl/en/') {
+          return { ...item, url: 'https://russchenmedia.com/' };
+        }
+        return item;
       },
     }),
   ],

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -1,6 +1,6 @@
 ---
 import type { Locale } from '../i18n/config';
-import { locales, localeNames, homePath } from '../i18n/config';
+import { locales, localeNames, localeDomains } from '../i18n/config';
 import { useUI } from '../i18n/ui';
 import { site } from '../data/site';
 
@@ -9,7 +9,6 @@ interface Props {
 }
 const { locale } = Astro.props;
 const t = useUI(locale);
-const home = homePath(locale);
 
 const sections = [
   { href: '#diensten', label: t.nav.services },
@@ -21,7 +20,7 @@ const sections = [
 
 <header class="nav">
   <div class="container nav__inner">
-    <a class="nav__brand" href={home} aria-label={site.name}>
+    <a class="nav__brand" href="/" aria-label={site.name}>
       <img src="/images/russchenmedia-logo.png" alt={site.name} width="40" height="36" />
       <span>{site.name}</span>
     </a>
@@ -40,7 +39,7 @@ const sections = [
         {
           locales.map((l) => (
             <a
-              href={homePath(l)}
+              href={`${localeDomains[l]}/`}
               class={`nav__lang-link${l === locale ? ' is-active' : ''}`}
               aria-current={l === locale ? 'true' : undefined}
               hreflang={l}

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -7,6 +7,12 @@ export const localeNames: Record<Locale, string> = {
   en: 'English',
 };
 
+// Each language has its own canonical domain: Dutch on .nl, English on .com.
+export const localeDomains: Record<Locale, string> = {
+  nl: 'https://russchenmedia.nl',
+  en: 'https://russchenmedia.com',
+};
+
 /** Resolve the active locale from the request URL (/en/... => 'en'). */
 export function getLocale(url: URL): Locale {
   const seg = url.pathname.split('/').filter(Boolean)[0];

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -2,7 +2,7 @@
 import '../styles/global.css';
 import { site } from '../data/site';
 import type { Locale } from '../i18n/config';
-import { locales, localizedPath, defaultLocale } from '../i18n/config';
+import { locales, defaultLocale, localeDomains } from '../i18n/config';
 import { useUI } from '../i18n/ui';
 
 interface Props {
@@ -16,17 +16,19 @@ const t = useUI(locale);
 const pageTitle = title ?? t.meta.title;
 const pageDesc = description ?? t.meta.description;
 
-const canonical = new URL(Astro.url.pathname, site.url).href;
-const ogImage = new URL('/images/og-russchenmedia.png', site.url).href;
-
-// Build hreflang alternates from the locale-agnostic path.
+// Locale-agnostic path (strip a leading /en). Each locale resolves to its own
+// canonical domain, so the English pages are canonical on russchenmedia.com.
 const segs = Astro.url.pathname.split('/').filter(Boolean);
 if ((locales as readonly string[]).includes(segs[0])) segs.shift();
 const logical = '/' + segs.join('/');
+
+const canonical = new URL(logical, localeDomains[locale]).href;
+const ogImage = new URL('/images/og-russchenmedia.png', localeDomains[locale]).href;
 const alternates = locales.map((l) => ({
   hreflang: l,
-  href: new URL(localizedPath(logical, l), site.url).href,
+  href: new URL(logical, localeDomains[l]).href,
 }));
+const xDefaultHref = new URL(logical, localeDomains[defaultLocale]).href;
 
 const jsonLd = {
   '@context': 'https://schema.org',
@@ -64,7 +66,7 @@ const cfToken = site.cloudflareAnalyticsToken;
     <meta name="description" content={pageDesc} />
     <link rel="canonical" href={canonical} />
     {alternates.map((a) => <link rel="alternate" hreflang={a.hreflang} href={a.href} />)}
-    <link rel="alternate" hreflang="x-default" href={new URL(localizedPath(logical, defaultLocale), site.url).href} />
+    <link rel="alternate" hreflang="x-default" href={xDefaultHref} />
 
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />

--- a/worker/index.js
+++ b/worker/index.js
@@ -1,19 +1,42 @@
 /**
- * Static site served from the ASSETS binding, with host-based routing:
- * russchenmedia.com (and www) serve the English site at the root, while
- * russchenmedia.nl serves Dutch at the root and English under /en/.
+ * Static site served from the ASSETS binding with host-based routing.
+ *
+ * Dutch lives on russchenmedia.nl, English on russchenmedia.com. The English
+ * pages are built under /en/; the Worker serves them at the root of .com and
+ * consolidates every other English URL onto .com so there is one canonical
+ * English address.
  */
+const COM = 'https://russchenmedia.com';
+
 export default {
   async fetch(request, env) {
     const url = new URL(request.url);
     const host = url.hostname;
     const isCom = host === 'russchenmedia.com' || host === 'www.russchenmedia.com';
+    const isNl = host === 'russchenmedia.nl' || host === 'www.russchenmedia.nl';
 
-    // On the .com domain, serve the English homepage at the root.
-    if (isCom && (url.pathname === '/' || url.pathname === '')) {
-      const target = new URL(request.url);
-      target.pathname = '/en/';
-      return env.ASSETS.fetch(new Request(target, request));
+    if (isCom) {
+      // English homepage at the .com root.
+      if (url.pathname === '/' || url.pathname === '') {
+        const target = new URL(request.url);
+        target.pathname = '/en/';
+        return env.ASSETS.fetch(new Request(target, request));
+      }
+      // No /en/ duplicate on .com: strip the prefix.
+      if (url.pathname === '/en' || url.pathname.startsWith('/en/')) {
+        const rest = url.pathname.replace(/^\/en/, '') || '/';
+        return Response.redirect(COM + rest + url.search, 301);
+      }
+      return env.ASSETS.fetch(request);
+    }
+
+    if (isNl) {
+      // English is canonical on .com, so move .nl/en/* there.
+      if (url.pathname === '/en' || url.pathname.startsWith('/en/')) {
+        const rest = url.pathname.replace(/^\/en/, '') || '/';
+        return Response.redirect(COM + rest + url.search, 301);
+      }
+      return env.ASSETS.fetch(request);
     }
 
     return env.ASSETS.fetch(request);


### PR DESCRIPTION
Promotes russchenmedia.com from "serves a copy of .nl/en" to its own canonical English site.

- **Per-locale canonical domains**: Dutch on \`russchenmedia.nl\`, English on \`russchenmedia.com\`.
- **Base**: \`canonical\`, \`og:url\`, \`og:image\` and \`hreflang\` resolve to each locale's own domain. English pages are now canonical on \`.com\`.
- **Nav switcher**: links cross-domain (NL → .nl, EN → .com).
- **Worker**: \`301\` redirects \`.nl/en/*\` and \`.com/en/*\` → \`.com/*\` so English has a single canonical address.
- **Sitemap**: lists \`russchenmedia.nl/\` and \`russchenmedia.com/\` (no /en/ duplicate).

Verified: NL canonical=.nl/ (hreflang en=.com/), EN canonical=.com/ (hreflang nl=.nl/), sitemap clean. \`astro build\` + \`check\` 0 issues, \`wrangler deploy --dry-run\` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)