### PR TITLE
Bilingual privacy statement + general .com routing

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -16,11 +16,12 @@ export default defineConfig({
   },
   integrations: [
     sitemap({
-      // English is canonical on russchenmedia.com, so map the built /en/ URL
-      // to its .com address in the sitemap.
+      // English is canonical on russchenmedia.com, so map built /en/ URLs to
+      // their .com addresses in the sitemap.
       serialize(item) {
-        if (item.url === 'https://russchenmedia.nl/en/') {
-          return { ...item, url: 'https://russchenmedia.com/' };
+        const prefix = 'https://russchenmedia.nl/en/';
+        if (item.url.startsWith(prefix)) {
+          return { ...item, url: 'https://russchenmedia.com/' + item.url.slice(prefix.length) };
         }
         return item;
       },

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -13,57 +13,115 @@ const year = new Date().getFullYear();
 ---
 
 <footer class="footer">
-  <div class="container footer__inner">
-    <span class="footer__copy">© {year} {site.name}, {site.location}</span>
+  <div class="container">
+    <div class="footer__top">
+      <div class="footer__brand">
+        <a class="footer__name" href="/">
+          <img src="/images/russchenmedia-logo.png" alt="" width="28" height="25" />
+          <span>{site.name}</span>
+        </a>
+        <p class="footer__contact">
+          <a href={`mailto:${site.email}`}>{site.email}</a>
+          <span aria-hidden="true">·</span>
+          <a href={`tel:${site.phoneHref}`}>{site.phone}</a>
+        </p>
+      </div>
 
-    <nav class="footer__links" aria-label="Footer">
-      <a href={`mailto:${site.email}`}>{site.email}</a>
-      <a href={`tel:${site.phoneHref}`}>{site.phone}</a>
-      <a href={site.social.github} target="_blank" rel="noopener">GitHub</a>
-      <a href={site.social.personal} target="_blank" rel="noopener">martijnrusschen.nl</a>
-      <a href="/privacy">{privacy[locale].navLabel}</a>
-    </nav>
+      <nav class="footer__nav" aria-label="Footer">
+        <a href={site.social.github} target="_blank" rel="noopener">GitHub</a>
+        <a href={site.social.personal} target="_blank" rel="noopener">martijnrusschen.nl</a>
+        <a href="/privacy">{privacy[locale].navLabel}</a>
+      </nav>
+    </div>
 
-    <a class="footer__top" href="#top">{t.footer.backToTop} ↑</a>
+    <div class="footer__bar">
+      <span>© {year} {site.name}, {site.location}</span>
+      <a class="footer__totop" href="#top">{t.footer.backToTop} ↑</a>
+    </div>
   </div>
 </footer>
 
 <style>
   .footer {
     border-top: 1px solid var(--color-border);
-    padding-block: 28px;
+    padding-block: 40px 24px;
+    color: var(--color-muted);
     font-size: 0.9rem;
-    color: var(--color-muted);
-  }
-
-  .footer__inner {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    gap: 14px 24px;
-    flex-wrap: wrap;
-  }
-
-  .footer__links {
-    display: inline-flex;
-    gap: 18px;
-    flex-wrap: wrap;
-  }
-
-  .footer__links a {
-    color: var(--color-muted);
-  }
-
-  .footer__links a:hover {
-    color: var(--color-accent);
   }
 
   .footer__top {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 24px 40px;
+    flex-wrap: wrap;
+  }
+
+  .footer__name {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    color: var(--color-text);
+    font-weight: 700;
+  }
+
+  .footer__name img {
+    width: 24px;
+    height: auto;
+  }
+
+  .footer__contact {
+    margin-top: 10px;
+    display: flex;
+    gap: 10px;
+    align-items: center;
+    flex-wrap: wrap;
+  }
+
+  .footer__contact a {
     color: var(--color-muted);
   }
 
-  @media (max-width: 700px) {
-    .footer__inner {
+  .footer__contact a:hover {
+    color: var(--color-accent);
+  }
+
+  .footer__nav {
+    display: flex;
+    gap: 20px;
+    flex-wrap: wrap;
+  }
+
+  .footer__nav a {
+    color: var(--color-muted);
+  }
+
+  .footer__nav a:hover {
+    color: var(--color-accent);
+  }
+
+  .footer__bar {
+    margin-top: 28px;
+    padding-top: 18px;
+    border-top: 1px solid var(--color-border);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+    font-size: 0.84rem;
+  }
+
+  .footer__totop {
+    color: var(--color-muted);
+  }
+
+  .footer__totop:hover {
+    color: var(--color-accent);
+  }
+
+  @media (max-width: 540px) {
+    .footer__bar {
       justify-content: center;
       text-align: center;
     }

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,6 +1,7 @@
 ---
 import type { Locale } from '../i18n/config';
 import { useUI } from '../i18n/ui';
+import { privacy } from '../i18n/legal';
 import { site } from '../data/site';
 
 interface Props {
@@ -20,6 +21,7 @@ const year = new Date().getFullYear();
       <a href={`tel:${site.phoneHref}`}>{site.phone}</a>
       <a href={site.social.github} target="_blank" rel="noopener">GitHub</a>
       <a href={site.social.personal} target="_blank" rel="noopener">martijnrusschen.nl</a>
+      <a href="/privacy">{privacy[locale].navLabel}</a>
     </nav>
 
     <a class="footer__top" href="#top">{t.footer.backToTop} ↑</a>

--- a/src/components/LegalPage.astro
+++ b/src/components/LegalPage.astro
@@ -1,0 +1,79 @@
+---
+import Base from '../layouts/Base.astro';
+import Nav from './Nav.astro';
+import Footer from './Footer.astro';
+import { site } from '../data/site';
+import type { Locale } from '../i18n/config';
+import type { LegalDoc } from '../i18n/legal';
+
+interface Props {
+  locale: Locale;
+  doc: LegalDoc;
+}
+const { locale, doc } = Astro.props;
+---
+
+<Base locale={locale} title={`${doc.title} | ${site.name}`}>
+  <span id="top"></span>
+  <Nav locale={locale} />
+  <main id="main" class="section">
+    <div class="container legal">
+      <p class="eyebrow">{doc.navLabel}</p>
+      <h1 class="section-title">{doc.title}</h1>
+      <p class="legal__updated">{doc.updated}</p>
+      <p class="legal__intro">{doc.intro}</p>
+      {
+        doc.sections.map((s) => (
+          <section class="legal__section">
+            <h2>{s.heading}</h2>
+            {s.body.map((p) => (
+              <p set:html={p} />
+            ))}
+          </section>
+        ))
+      }
+    </div>
+  </main>
+  <Footer locale={locale} />
+</Base>
+
+<style>
+  .legal {
+    max-width: 72ch;
+  }
+
+  .legal__updated {
+    margin-top: 8px;
+    color: var(--color-muted);
+    font-size: 0.9rem;
+  }
+
+  .legal__intro {
+    margin-top: 18px;
+    color: var(--color-muted);
+  }
+
+  .legal__section {
+    margin-top: 32px;
+  }
+
+  .legal__section h2 {
+    font-size: 1.2rem;
+    font-weight: 700;
+    margin-bottom: 10px;
+  }
+
+  .legal__section p {
+    color: var(--color-muted);
+  }
+
+  .legal__section p + p {
+    margin-top: 12px;
+  }
+
+  .legal__section a {
+    color: var(--color-accent);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+</style>

--- a/src/i18n/legal.ts
+++ b/src/i18n/legal.ts
@@ -1,0 +1,107 @@
+import type { Locale } from './config';
+
+export interface LegalSection {
+  heading: string;
+  body: string[]; // may contain inline <a> markup
+}
+
+export interface LegalDoc {
+  navLabel: string;
+  title: string;
+  updated: string;
+  intro: string;
+  sections: LegalSection[];
+}
+
+const email = 'info@russchenmedia.nl';
+const mail = `<a href="mailto:${email}">${email}</a>`;
+
+export const privacy: Record<Locale, LegalDoc> = {
+  nl: {
+    navLabel: 'Privacy',
+    title: 'Privacyverklaring',
+    updated: 'Laatst bijgewerkt: 14 juni 2026',
+    intro:
+      'Russchen Media respecteert je privacy en verwerkt persoonsgegevens alleen waar dat nodig is. Hieronder lees je welke gegevens we verwerken en waarom.',
+    sections: [
+      {
+        heading: 'Verwerkingsverantwoordelijke',
+        body: [
+          `Russchen Media, gevestigd in Assen, is verantwoordelijk voor de verwerking van persoonsgegevens zoals beschreven in deze verklaring. Vragen? Mail naar ${mail}.`,
+        ],
+      },
+      {
+        heading: 'Contactformulier',
+        body: [
+          'Gebruik je het contactformulier, dan verwerken we je naam, e-mailadres en bericht, uitsluitend om je vraag te beantwoorden. Het versturen verloopt via Web3Forms, dat het bericht namens ons aflevert. We bewaren berichten zolang nodig is om je vraag af te handelen.',
+        ],
+      },
+      {
+        heading: 'Statistieken',
+        body: [
+          'We meten websitebezoek met Cloudflare Web Analytics. Dit werkt zonder cookies en zonder dat er persoonlijke profielen worden opgebouwd.',
+        ],
+      },
+      {
+        heading: 'Cookies',
+        body: [
+          'Deze site plaatst geen tracking- of marketingcookies. We bewaren alleen lokaal je themavoorkeur (licht of donker) in je browser; die gegevens worden nergens naartoe gestuurd.',
+        ],
+      },
+      {
+        heading: 'Hosting',
+        body: ['De website wordt gehost via Cloudflare.'],
+      },
+      {
+        heading: 'Je rechten',
+        body: [
+          `Je hebt recht op inzage, correctie of verwijdering van je persoonsgegevens. Stuur daarvoor een bericht naar ${mail}.`,
+        ],
+      },
+    ],
+  },
+
+  en: {
+    navLabel: 'Privacy',
+    title: 'Privacy statement',
+    updated: 'Last updated: 14 June 2026',
+    intro:
+      'Russchen Media respects your privacy and only processes personal data where necessary. Below you can read which data we process and why.',
+    sections: [
+      {
+        heading: 'Data controller',
+        body: [
+          `Russchen Media, based in Assen (the Netherlands), is responsible for the processing of personal data described in this statement. Questions? Email ${mail}.`,
+        ],
+      },
+      {
+        heading: 'Contact form',
+        body: [
+          'If you use the contact form, we process your name, email address and message solely to answer your question. Submissions are handled by Web3Forms, which delivers the message on our behalf. We keep messages for as long as needed to handle your request.',
+        ],
+      },
+      {
+        heading: 'Analytics',
+        body: [
+          'We measure site visits with Cloudflare Web Analytics. It works without cookies and without building personal profiles.',
+        ],
+      },
+      {
+        heading: 'Cookies',
+        body: [
+          'This site sets no tracking or marketing cookies. We only store your theme preference (light or dark) locally in your browser; that data is never sent anywhere.',
+        ],
+      },
+      {
+        heading: 'Hosting',
+        body: ['The website is hosted on Cloudflare.'],
+      },
+      {
+        heading: 'Your rights',
+        body: [
+          `You have the right to access, correct or delete your personal data. To do so, email ${mail}.`,
+        ],
+      },
+    ],
+  },
+};

--- a/src/pages/en/privacy.astro
+++ b/src/pages/en/privacy.astro
@@ -1,0 +1,6 @@
+---
+import LegalPage from '../../components/LegalPage.astro';
+import { privacy } from '../../i18n/legal';
+---
+
+<LegalPage locale="en" doc={privacy.en} />

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -1,0 +1,6 @@
+---
+import LegalPage from '../components/LegalPage.astro';
+import { privacy } from '../i18n/legal';
+---
+
+<LegalPage locale="nl" doc={privacy.nl} />

--- a/worker/index.js
+++ b/worker/index.js
@@ -1,12 +1,27 @@
 /**
  * Static site served from the ASSETS binding with host-based routing.
  *
- * Dutch lives on russchenmedia.nl, English on russchenmedia.com. The English
- * pages are built under /en/; the Worker serves them at the root of .com and
- * consolidates every other English URL onto .com so there is one canonical
- * English address.
+ * Dutch lives on russchenmedia.nl, English on russchenmedia.com. English pages
+ * are built under /en/; on .com the Worker serves them at the root (so /privacy
+ * on .com maps to /en/privacy), and consolidates every /en/ URL onto .com so
+ * each language has a single canonical address.
  */
 const COM = 'https://russchenmedia.com';
+
+// Shared, non-localized files that must be served as-is on every host.
+function isSharedAsset(pathname) {
+  return (
+    pathname.startsWith('/_astro/') ||
+    pathname.startsWith('/images/') ||
+    pathname.startsWith('/sitemap') ||
+    pathname.startsWith('/icon-') ||
+    pathname === '/favicon.ico' ||
+    pathname === '/apple-touch-icon.png' ||
+    pathname === '/robots.txt' ||
+    pathname === '/site.webmanifest' ||
+    /\.[a-z0-9]+$/i.test(pathname)
+  );
+}
 
 export default {
   async fetch(request, env) {
@@ -16,16 +31,16 @@ export default {
     const isNl = host === 'russchenmedia.nl' || host === 'www.russchenmedia.nl';
 
     if (isCom) {
-      // English homepage at the .com root.
-      if (url.pathname === '/' || url.pathname === '') {
-        const target = new URL(request.url);
-        target.pathname = '/en/';
-        return env.ASSETS.fetch(new Request(target, request));
-      }
       // No /en/ duplicate on .com: strip the prefix.
       if (url.pathname === '/en' || url.pathname.startsWith('/en/')) {
         const rest = url.pathname.replace(/^\/en/, '') || '/';
         return Response.redirect(COM + rest + url.search, 301);
+      }
+      // Shared assets pass through; localized pages map to /en/*.
+      if (!isSharedAsset(url.pathname)) {
+        const target = new URL(request.url);
+        target.pathname = '/en' + (url.pathname === '/' ? '/' : url.pathname);
+        return env.ASSETS.fetch(new Request(target, request));
       }
       return env.ASSETS.fetch(request);
     }


### PR DESCRIPTION
- Adds a concise bilingual **privacy statement**: `/privacy` (NL), `/en/privacy` (EN), linked in the footer. Covers the contact form data, cookieless Cloudflare analytics, no tracking cookies, and data-access rights.
- **Worker**: now maps all non-asset paths on .com to their `/en/` build (so `russchenmedia.com/privacy` serves the English page), not just the homepage. Shared assets pass through.
- **Sitemap**: maps any built `/en/*` URL to its `.com` address.

Verified: NL privacy canonical .nl/privacy, EN privacy canonical .com/privacy, sitemap clean, build + check + dry-run OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)